### PR TITLE
Feature: Add ammo count in gun lore

### DIFF
--- a/src/main/java/me/zombie_striker/qg/QAMain.java
+++ b/src/main/java/me/zombie_striker/qg/QAMain.java
@@ -247,6 +247,7 @@ public class QAMain extends JavaPlugin {
     public static boolean hasViaRewind = false;
     public static boolean AUTOUPDATE = true;
     public static boolean SWAP_TO_LMB_SHOOT = true;
+    public static boolean SHOW_BULLETS_LORE = false;
     public static boolean ENABLE_LORE_INFO = true;
     public static boolean ENABLE_LORE_HELP = true;
     public static boolean AutoDetectResourcepackVersion = true;
@@ -995,6 +996,7 @@ public class QAMain extends JavaPlugin {
 
         orderShopByPrice = (boolean) a("Order-Shop-By-Price", orderShopByPrice);
 
+        SHOW_BULLETS_LORE = (boolean) a("enable_lore_gun-bullets", false);
         ENABLE_LORE_INFO = (boolean) a("enable_lore_gun-info_messages", true);
         ENABLE_LORE_HELP = (boolean) a("enable_lore_control-help_messages", true);
 

--- a/src/main/java/me/zombie_striker/qg/guns/Gun.java
+++ b/src/main/java/me/zombie_striker/qg/guns/Gun.java
@@ -174,7 +174,7 @@ public class Gun extends CustomBaseObject implements ArmoryBaseObject, Comparabl
             nbt.setInteger("ammo", amount);
         });
 
-        if (QAMain.ENABLE_LORE_INFO && g != null) {
+        if (QAMain.SHOW_BULLETS_LORE && g != null) {
             ItemMeta meta = current.getItemMeta();
             if (meta == null || !meta.hasLore()) return;
 
@@ -208,7 +208,7 @@ public class Gun extends CustomBaseObject implements ArmoryBaseObject, Comparabl
         List<String> lore = (current != null && current.hasItemMeta() && current.getItemMeta().hasLore()) ? current.getItemMeta().getLore() : new ArrayList<>();
         OLD_ItemFact.addVariantData(null, lore, g);
         if (QAMain.ENABLE_LORE_INFO) {
-            lore.add(QAMain.S_ITEM_BULLETS + ": " + amount + "/" + g.getMaxBullets());
+            if (QAMain.SHOW_BULLETS_LORE) lore.add(QAMain.S_ITEM_BULLETS + ": " + amount + "/" + g.getMaxBullets());
             lore.add(QAMain.S_ITEM_DAMAGE + ": " + g.getDamage());
             lore.add(QAMain.S_ITEM_DPS + ": "
                     + (g.isAutomatic()

--- a/src/main/java/me/zombie_striker/qg/guns/Gun.java
+++ b/src/main/java/me/zombie_striker/qg/guns/Gun.java
@@ -173,6 +173,26 @@ public class Gun extends CustomBaseObject implements ArmoryBaseObject, Comparabl
         NBT.modify(current, nbt -> {
             nbt.setInteger("ammo", amount);
         });
+        if (QAMain.ENABLE_LORE_INFO) {
+            ItemMeta meta = current.getItemMeta();
+            if (meta == null) return;
+            List<String> lore = meta.getLore();
+            if (lore == null) return;
+            updateAmmoInLore(lore, amount);
+            meta.setLore(lore);
+            current.setItemMeta(meta);
+        }
+    }
+
+    private static void updateAmmoInLore(List<String> lore, int amount) {
+        for (int i = 0; i < lore.size(); i++) {
+            String loreLine = lore.get(i);
+            if (loreLine.startsWith(QAMain.S_ITEM_BULLETS)) {
+                String maxBullets = loreLine.substring(loreLine.indexOf("/") + 1);
+                lore.set(i, QAMain.S_ITEM_BULLETS + ": " + (amount) + "/" + maxBullets);
+                break;
+            }
+        }
     }
 
     public static void updateAmmo(Gun g, Player player, int amount) {
@@ -187,6 +207,7 @@ public class Gun extends CustomBaseObject implements ArmoryBaseObject, Comparabl
         List<String> lore = (current != null && current.hasItemMeta() && current.getItemMeta().hasLore()) ? current.getItemMeta().getLore() : new ArrayList<>();
         OLD_ItemFact.addVariantData(null, lore, g);
         if (QAMain.ENABLE_LORE_INFO) {
+            lore.add(QAMain.S_ITEM_BULLETS + ": " + amount + "/" + g.getMaxBullets());
             lore.add(QAMain.S_ITEM_DAMAGE + ": " + g.getDamage());
             lore.add(QAMain.S_ITEM_DPS + ": "
                     + (g.isAutomatic()

--- a/src/main/java/me/zombie_striker/qg/guns/Gun.java
+++ b/src/main/java/me/zombie_striker/qg/guns/Gun.java
@@ -173,30 +173,34 @@ public class Gun extends CustomBaseObject implements ArmoryBaseObject, Comparabl
         NBT.modify(current, nbt -> {
             nbt.setInteger("ammo", amount);
         });
-        if (QAMain.ENABLE_LORE_INFO) {
+        System.out.println(g);
+        System.out.println(current);
+        System.out.println(amount);
+
+        if (QAMain.ENABLE_LORE_INFO && g != null) {
             ItemMeta meta = current.getItemMeta();
-            if (meta == null) return;
+            if (meta == null || !meta.hasLore()) return;
+
             List<String> lore = meta.getLore();
             if (lore == null) return;
-            updateAmmoInLore(lore, amount);
+
+            for (int i = 0; i < lore.size(); i++) {
+                String loreLine = lore.get(i);
+                if (loreLine.startsWith(QAMain.S_ITEM_BULLETS)) {
+                    lore.set(i, QAMain.S_ITEM_BULLETS + ": " + (amount) + "/" + g.getMaxBullets());
+                    break;
+                }
+            }
+
             meta.setLore(lore);
             current.setItemMeta(meta);
         }
     }
 
-    private static void updateAmmoInLore(List<String> lore, int amount) {
-        for (int i = 0; i < lore.size(); i++) {
-            String loreLine = lore.get(i);
-            if (loreLine.startsWith(QAMain.S_ITEM_BULLETS)) {
-                String maxBullets = loreLine.substring(loreLine.indexOf("/") + 1);
-                lore.set(i, QAMain.S_ITEM_BULLETS + ": " + (amount) + "/" + maxBullets);
-                break;
-            }
-        }
-    }
-
     public static void updateAmmo(Gun g, Player player, int amount) {
         ItemStack current = player.getInventory().getItemInHand();
+
+        if (g == null) g = QualityArmory.getGun(current);
         updateAmmo(g, current, amount);
 
         if (QAMain.showAmmoInXPBar)

--- a/src/main/java/me/zombie_striker/qg/guns/Gun.java
+++ b/src/main/java/me/zombie_striker/qg/guns/Gun.java
@@ -173,9 +173,6 @@ public class Gun extends CustomBaseObject implements ArmoryBaseObject, Comparabl
         NBT.modify(current, nbt -> {
             nbt.setInteger("ammo", amount);
         });
-        System.out.println(g);
-        System.out.println(current);
-        System.out.println(amount);
 
         if (QAMain.ENABLE_LORE_INFO && g != null) {
             ItemMeta meta = current.getItemMeta();

--- a/wiki/config/main.md
+++ b/wiki/config/main.md
@@ -88,4 +88,6 @@ Below you can find a list of all the options that you can configure and their ex
 * **DestructableMaterials**: `[MATERIAL_NAME_HERE]` - A list of material names (e.g., `GLASS`, `WHITE_WOOL`) that can be broken by bullets if `enableExplosionDamage` is appropriately configured or via specific weapon properties.
 * **RegenDestructableBlocksAfter**: `-1` - The time in server ticks after which a block destroyed by a QualityArmory weapon/explosion will regenerate. `-1` disables regeneration.
 * **overrideAttackSpeed**: `true` - If `true` (primarily for 1.14+), overrides the default item attack speed attribute, potentially allowing faster firing rates.
+* **enable_lore_gun-info_messages**: `true` - If `true`, displays weapon statistics like damage, ammo type, etc., in the item's lore text.
+* **enable_lore_gun-bullets**: `false` - If `true`, displays the bullet amount in the item's lore text. This will make the gun go "up and down" when shooting.
 * **DefaultResourcepack**: Defines the resource pack URLs. Refer to [ResourcePack Configuration](resourcepack.md) for more information.


### PR DESCRIPTION
Show and update current ammo count in gun lore if QAMain.ENABLE_LORE_INFO is true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The ammo count for guns is now displayed and updated in the item's lore when enabled, providing real-time ammo information directly in the item description.
- **Documentation**
  - Added configuration options to control the display of weapon stats and ammo count in item lore, including notes on visual effects when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->