### PR TITLE
Feature: new Misc-Ammo type

### DIFF
--- a/src/main/java/me/zombie_striker/qg/QAMain.java
+++ b/src/main/java/me/zombie_striker/qg/QAMain.java
@@ -16,6 +16,7 @@ import me.zombie_striker.customitemmanager.qa.AbstractCustomGunItem;
 import me.zombie_striker.customitemmanager.qa.ItemBridgePatch;
 import me.zombie_striker.customitemmanager.qa.versions.V1_13.CustomGunItem;
 import me.zombie_striker.qg.ammo.Ammo;
+import me.zombie_striker.qg.ammo.AmmoBox;
 import me.zombie_striker.qg.api.QAGunGiveEvent;
 import me.zombie_striker.qg.api.QualityArmory;
 import me.zombie_striker.qg.armor.ArmorObject;
@@ -1634,6 +1635,13 @@ public class QAMain extends JavaPlugin {
                             if (args.length > 3)
                                 amount = Integer.parseInt(args[3]);
                             QualityArmory.addAmmoToInventory(who, (Ammo) g, amount);
+                        } else if (g instanceof AmmoBox) {
+                            temp = CustomItemManager.getItemType("gun").getItem(g.getItemData());
+                            ((AmmoBox) g).updateAmmoLore(temp, ((AmmoBox) g).getMaxAmmoCount());
+                            ItemMeta meta = temp.getItemMeta();
+                            meta.setMaxStackSize(1);
+                            temp.setItemMeta(meta);
+                            who.getInventory().addItem(temp);
                         } else {
                             temp = CustomItemManager.getItemType("gun").getItem(g.getItemData().getMat(), g.getItemData().getData(), g.getItemData().getVariant());
                             temp.setAmount(g.getCraftingReturn());

--- a/src/main/java/me/zombie_striker/qg/QAMain.java
+++ b/src/main/java/me/zombie_striker/qg/QAMain.java
@@ -1638,9 +1638,9 @@ public class QAMain extends JavaPlugin {
                         } else if (g instanceof AmmoBox) {
                             temp = CustomItemManager.getItemType("gun").getItem(g.getItemData());
                             ((AmmoBox) g).updateAmmoLore(temp, ((AmmoBox) g).getMaxAmmoCount());
-                            ItemMeta meta = temp.getItemMeta();
-                            meta.setMaxStackSize(1);
-                            temp.setItemMeta(meta);
+                            NBT.modify(temp, nbt -> {
+                                nbt.setUUID("uuid", UUID.randomUUID());
+                            });
                             who.getInventory().addItem(temp);
                         } else {
                             temp = CustomItemManager.getItemType("gun").getItem(g.getItemData().getMat(), g.getItemData().getData(), g.getItemData().getVariant());

--- a/src/main/java/me/zombie_striker/qg/ammo/AmmoBox.java
+++ b/src/main/java/me/zombie_striker/qg/ammo/AmmoBox.java
@@ -1,0 +1,67 @@
+package me.zombie_striker.qg.ammo;
+
+import me.zombie_striker.customitemmanager.MaterialStorage;
+import me.zombie_striker.qg.api.QualityArmory;
+import me.zombie_striker.qg.miscitems.AmmoBag;
+import me.zombie_striker.qg.utils.LocalUtils;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class AmmoBox extends AmmoBag {
+    private final int maxAmmoCount;
+    private final Ammo ammoType;
+
+    public AmmoBox(MaterialStorage ms, String name, String displayname, ItemStack[] ings, int cost, int max, String ammoType) {
+        super(ms, name, displayname, ings, max, cost);
+        this.maxAmmoCount = max;
+        this.ammoType = QualityArmory.getAmmoByName(ammoType);
+        if (this.ammoType == null)
+            throw new IllegalArgumentException("Invalid ammo type: " + ammoType);
+    }
+
+    @Override
+    public boolean onRMB(Player shooter, ItemStack usedItem) {
+        return false;
+    }
+
+    @Override
+    public boolean onLMB(Player shooter, ItemStack usedItem) {
+        return false;
+    }
+
+    @Override
+    public void updateAmmoLore(@NotNull ItemStack item, int newAmmo) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+
+        meta.setDisplayName(ammoType.getDisplayName() +
+                ChatColor.GREEN + " " + newAmmo + ChatColor.GRAY + " | " + ChatColor.RED + maxAmmoCount
+        );
+
+        item.setItemMeta(meta);
+    }
+
+    @Override
+    public int getAmmo(@NotNull ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return 0;
+
+        String displayName = ChatColor.stripColor(meta.getDisplayName());
+        String[] split = displayName.split(" ");
+
+        return Integer.parseInt(split[1]);
+    }
+
+    @Override
+    public @Nullable Ammo getAmmoType(@NotNull ItemStack item) {
+        return ammoType;
+    }
+
+    public int getMaxAmmoCount() {
+        return maxAmmoCount;
+    }
+}

--- a/src/main/java/me/zombie_striker/qg/api/QualityArmory.java
+++ b/src/main/java/me/zombie_striker/qg/api/QualityArmory.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map.Entry;
 
 import me.zombie_striker.customitemmanager.*;
+import me.zombie_striker.qg.ammo.AmmoBox;
 import me.zombie_striker.qg.handlers.HotbarMessager;
 import me.zombie_striker.qg.handlers.IronsightsHandler;
 import me.zombie_striker.qg.hooks.protection.ProtectionHandler;
@@ -729,13 +730,19 @@ public class QualityArmory {
 					if (ammoType != null && ammoType.equals(a)) {
 						int amountInBag = ab.getAmmo(is);
 
+						int newAmount = 0;
+
 						if (amountInBag >= remaining) {
-							ab.updateAmmoLore(is, amountInBag - remaining);
+							ab.updateAmmoLore(is, newAmount = (amountInBag - remaining));
 							remaining = 0;
 						} else {
 							ab.updateAmmoLore(is, 0);
 							remaining -= amountInBag;
 						}
+
+						if (newAmount == 0 && ab instanceof AmmoBox)
+							player.getInventory().setItem(i, new ItemStack(Material.AIR));
+
 					}
 
 				}

--- a/src/main/java/me/zombie_striker/qg/config/GunYMLLoader.java
+++ b/src/main/java/me/zombie_striker/qg/config/GunYMLLoader.java
@@ -4,6 +4,7 @@ import me.zombie_striker.customitemmanager.CustomBaseObject;
 import me.zombie_striker.customitemmanager.MaterialStorage;
 import me.zombie_striker.qg.QAMain;
 import me.zombie_striker.qg.ammo.Ammo;
+import me.zombie_striker.qg.ammo.AmmoBox;
 import me.zombie_striker.qg.ammo.AmmoType;
 import me.zombie_striker.qg.armor.Helmet;
 import me.zombie_striker.qg.attachments.AttachmentBase;
@@ -219,6 +220,8 @@ public class GunYMLLoader {
 								QAMain.miscRegister.put(ms, base=new MedKit(ms, name, displayname, materails, price));
 							if (wt == WeaponType.AMMO_BAG)
 								QAMain.miscRegister.put(ms, base=new AmmoBag(ms, name, displayname, materails, f2.getInt("max", 5), price));
+							if (wt == WeaponType.AMMO_BOX)
+								QAMain.miscRegister.put(ms, base=new AmmoBox(ms, name, displayname, materails, price, f2.getInt("max", 100), f2.getString("ammo_type_name", "invalid")));
 							if (wt == WeaponType.MELEE) {
 								QAMain.miscRegister.put(ms,
 										base = new MeleeItems(ms, name, displayname, materails, price, damage));

--- a/src/main/java/me/zombie_striker/qg/guns/utils/WeaponType.java
+++ b/src/main/java/me/zombie_striker/qg/guns/utils/WeaponType.java
@@ -3,7 +3,7 @@ package me.zombie_striker.qg.guns.utils;
 public enum WeaponType {
 	PISTOL(true), SMG(true), RPG(true), RIFLE(true), SHOTGUN(true), FLAMER(true), SNIPER(true), BIG_GUN(true), GRENADES(false), SMOKE_GRENADES(
 			false), FLASHBANGS(false), INCENDARY_GRENADES(false),MOLOTOV(false),PROXYMINES(false), STICKYGRENADE(false), MINES(
-					false), MELEE(false),  MISC(false), AMMO(false), HELMET(false), MEDKIT(false), AMMO_BAG(false), LAZER(true),BACKPACK(false),PARACHUTE(false),CUSTOM(false);
+					false), MELEE(false),  MISC(false), AMMO(false), HELMET(false), MEDKIT(false), AMMO_BAG(false), AMMO_BOX(false), LAZER(true),BACKPACK(false),PARACHUTE(false),CUSTOM(false);
 
 	private boolean isGun;
 


### PR DESCRIPTION

**Features-Advantages:**
1. It is a single ItemStack in an inventory, which can hold potentially **any number of ammo in one inventory slot**. 
(With default ammo it is usually limited by minecraft ItemStackMaxSize e.g. 64 for phantom_membrane)
2. **Fewer lags:** when a player is killed, all his items and usually many ItemStacks of ammo are dropped on the ground and caused lags. (Now it is a single ItemStack).
3. Is not stackable due to uuid saved in NBT.
4. Is removed from the inventory when empty (current ammo is 0).

**Potential-Disadvantages (can be customized / improved later):**
1. Hard-coded displayName format, colors and separator.
2. Requires AmmoType to exist.



**In-game-example:**
<img width="212" alt="in-game-example" src="https://github.com/user-attachments/assets/5ea28315-ceb9-482f-ad6c-b2155f52453d" />



**How to create:**
1. Put inside **misc** folder.
2. Create file e.g. box_ammo_762.yml


**box_ammo_762.yml content example:**
invalid: false
name: "box_762"
material: PHANTOM_MEMBRANE
id: 999
displayname: "<ammo_type_displayName> <green><current> <gray>| <red><max>" #unused, shows how it will look like in a game 
lore: []
price: 100
allowInShop: true
MiscType: AMMO_BOX
ammo_type_name: "762" # must match ammo name
max: 100 # max ammo count in a box


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced Ammo Box items, which serve as ammo containers with a fixed maximum ammo count and a specific ammo type.
  - Ammo Boxes are now supported as a new weapon type and can be configured and registered in the game.
  - Ammo Boxes are automatically removed from inventory when emptied.

- **Bug Fixes**
  - Improved inventory handling to ensure empty Ammo Boxes are properly removed after use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->