### PR TITLE
add full folia support, tested on 1.21.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
-            <version>2.15.7</version>
+            <version>2.16.0</version>
         </dependency>
 
         <!-- WorldGuard Wrapper -->

--- a/src/main/java/me/zombie_striker/customitemmanager/OLD_ItemFact.java
+++ b/src/main/java/me/zombie_striker/customitemmanager/OLD_ItemFact.java
@@ -10,7 +10,7 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +29,7 @@ public class OLD_ItemFact {
 		im.setDisplayName(g.getDisplayName() + QAMain.S_OUT_OF_AMMO);
 		k.setItemMeta(im);
 		player.getInventory().setItem(slot, k);
-		new BukkitRunnable() {
+		new FoliaRunnable() {
 			public void run() {
 				removeOutOfAmmoToDisplayname(g, player, k, slot);
 			}

--- a/src/main/java/me/zombie_striker/qg/GithubUpdater.java
+++ b/src/main/java/me/zombie_striker/qg/GithubUpdater.java
@@ -5,7 +5,7 @@ import java.net.*;
 import com.google.gson.*;
 import org.bukkit.*;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 public class GithubUpdater {
 
@@ -47,7 +47,7 @@ public class GithubUpdater {
 								+ main.getDescription().getName() + ": " + ChatColor.WHITE + tagname
 								+ ChatColor.LIGHT_PURPLE + " downloading now!!");
 
-				new BukkitRunnable() {
+				new FoliaRunnable() {
 
 					@Override
 					public void run() {

--- a/src/main/java/me/zombie_striker/qg/Metrics.java
+++ b/src/main/java/me/zombie_striker/qg/Metrics.java
@@ -27,6 +27,7 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPOutputStream;
 import javax.net.ssl.HttpsURLConnection;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
@@ -87,7 +88,7 @@ public class Metrics {
                         enabled,
                         this::appendPlatformData,
                         this::appendServiceData,
-                        submitDataTask -> Bukkit.getScheduler().runTask(plugin, submitDataTask),
+                        submitDataTask -> FoliaRunnable.runTask(plugin, submitDataTask),
                         plugin::isEnabled,
                         (message, error) -> this.plugin.getLogger().log(Level.WARNING, message, error),
                         (message) -> this.plugin.getLogger().log(Level.INFO, message),

--- a/src/main/java/me/zombie_striker/qg/QAMain.java
+++ b/src/main/java/me/zombie_striker/qg/QAMain.java
@@ -516,7 +516,8 @@ public class QAMain extends JavaPlugin {
         }
 
         try {
-            resourcepackwhitelist.save(new File(getDataFolder(), "resourcepackwhitelist.yml"));
+            if (resourcepackwhitelist != null)
+                resourcepackwhitelist.save(new File(getDataFolder(), "resourcepackwhitelist.yml"));
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/me/zombie_striker/qg/QAMain.java
+++ b/src/main/java/me/zombie_striker/qg/QAMain.java
@@ -64,7 +64,7 @@ import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
 
@@ -580,7 +580,7 @@ public class QAMain extends JavaPlugin {
 
         DEBUG(ChatColor.RED + "NOTICE ME");
         reloadVals();
-        new BukkitRunnable() {
+        new FoliaRunnable() {
             @Override
             public void run() {
                 for (Player player : Bukkit.getOnlinePlayers())
@@ -632,50 +632,47 @@ public class QAMain extends JavaPlugin {
         metrics.addCustomChart(
                 new Metrics.SimplePie("has_an_expansion_pack", () -> (expansionPacks.size() > 0) + ""));
         if (!CustomItemManager.isUsingCustomData()) {
-            new BukkitRunnable() {
-                @SuppressWarnings("deprecation")
+            new FoliaRunnable() {
                 public void run() {
                     try {
-                        // Cheaty, hacky fix
                         for (Player p : Bukkit.getOnlinePlayers()) {
-                            // if (p.getItemInHand().containsEnchantment(Enchantment.MENDING)) {
-                            if (p.getItemInHand() != null && p.getItemInHand().hasItemMeta())
-                                if (QualityArmory.isCustomItem(p.getItemInHand())) {
-                                    if (ITEM_enableUnbreakable && (!p.getItemInHand().getItemMeta().isUnbreakable()
-                                            && !ignoreUnbreaking)) {
-                                        ItemStack temp = p.getItemInHand();
-                                        int j = QualityArmory.findSafeSpot(temp, false, overrideURL);
-                                        temp.setDurability((short) Math.max(0, j - 1));
-                                        temp = Gun.removeCalculatedExtra(temp);
-                                        p.setItemInHand(temp);
-                                    }
-                                }
-                            try {
-
-                                // if
-                                // (p.getInventory().getItemInOffHand().containsEnchantment(Enchantment.MENDING))
-                                // {
-                                if (p.getInventory().getItemInOffHand() != null
-                                        && p.getInventory().getItemInOffHand().hasItemMeta())
-                                    if (QualityArmory.isCustomItem(p.getInventory().getItemInOffHand())) {
-                                        if (ITEM_enableUnbreakable && (!p.getInventory().getItemInOffHand().getItemMeta()
-                                                .isUnbreakable() && !ignoreUnbreaking)) {
-                                            ItemStack temp = p.getInventory().getItemInOffHand();
-                                            int j = QualityArmory.findSafeSpot(temp, false, overrideURL);
-                                            temp.setDurability((short) Math.max(0, j - 1));
-                                            temp = Gun.removeCalculatedExtra(temp);
-                                            p.getInventory().setItemInOffHand(temp);
-                                            return;
+                            final Player fp = p;
+                            FoliaRunnable.runEntityTask(QAMain.getInstance(), fp, () -> {
+                                try {
+                                    if (fp.getItemInHand() != null && fp.getItemInHand().hasItemMeta())
+                                        if (QualityArmory.isCustomItem(fp.getItemInHand())) {
+                                            if (ITEM_enableUnbreakable && (!fp.getItemInHand().getItemMeta().isUnbreakable()
+                                                    && !ignoreUnbreaking)) {
+                                                ItemStack temp = fp.getItemInHand();
+                                                int j = QualityArmory.findSafeSpot(temp, false, overrideURL);
+                                                temp.setDurability((short) Math.max(0, j - 1));
+                                                temp = Gun.removeCalculatedExtra(temp);
+                                                fp.setItemInHand(temp);
+                                            }
                                         }
+                                    try {
+                                        if (fp.getInventory().getItemInOffHand() != null
+                                                && fp.getInventory().getItemInOffHand().hasItemMeta())
+                                            if (QualityArmory.isCustomItem(fp.getInventory().getItemInOffHand())) {
+                                                if (ITEM_enableUnbreakable && (!fp.getInventory().getItemInOffHand().getItemMeta()
+                                                        .isUnbreakable() && !ignoreUnbreaking)) {
+                                                    ItemStack temp = fp.getInventory().getItemInOffHand();
+                                                    int j = QualityArmory.findSafeSpot(temp, false, overrideURL);
+                                                    temp.setDurability((short) Math.max(0, j - 1));
+                                                    temp = Gun.removeCalculatedExtra(temp);
+                                                    fp.getInventory().setItemInOffHand(temp);
+                                                }
+                                            }
+                                    } catch (Error | Exception e45) {
                                     }
-                            } catch (Error | Exception e45) {
-                            }
+                                } catch (Error | Exception e) {
+                                }
+                            });
                         }
                     } catch (Error | Exception catchy) {
-
                     }
                 }
-            }.runTaskTimer(this, 20, 15);
+            }.runTaskTimerAsynchronously(this, 20, 15);
         }
     }
 

--- a/src/main/java/me/zombie_striker/qg/api/QualityArmory.java
+++ b/src/main/java/me/zombie_striker/qg/api/QualityArmory.java
@@ -20,7 +20,7 @@ import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 import me.zombie_striker.qg.*;
 import me.zombie_striker.qg.ammo.Ammo;
@@ -42,7 +42,7 @@ public class QualityArmory {
 			int cost) {
 		File newGunsDir = new File(QAMain.getInstance().getDataFolder(), "newGuns");
 		final File gunFile = new File(newGunsDir, name);
-		new BukkitRunnable() {
+		new FoliaRunnable() {
 			public void run() {
 				GunYMLLoader.loadGuns(QAMain.getInstance(), gunFile);
 			}
@@ -96,7 +96,7 @@ public class QualityArmory {
 
 	@SuppressWarnings({"deprecation", "unchecked"})
 	public static void sendResourcepack(final Player player, final boolean warning) {
-		new BukkitRunnable() {
+		new FoliaRunnable() {
 			@Override
 			public void run() {
 				if (QAMain.namesToBypass.contains(player.getName())) {
@@ -114,7 +114,7 @@ public class QualityArmory {
 				if (QAMain.showCrashMessage)
 					player.sendMessage(LocalUtils.colorize(QAMain.prefix + QAMain.S_RESOURCEPACK_HELP));
 
-				new BukkitRunnable() {
+				new FoliaRunnable() {
 					@Override
 					public void run() {
 						try {
@@ -151,9 +151,9 @@ public class QualityArmory {
 
 						}
 					}
-				}.runTaskLater(QAMain.getInstance(), 20 * (warning ? 1 : 5));
+				}.runTaskLater(QAMain.getInstance(), player, 20 * (warning ? 1 : 5));
 			}
-		}.runTaskLater(QAMain.getInstance(), (long) (20 * QAMain.secondsTilSend));
+		}.runTaskLater(QAMain.getInstance(), player, (long) (20 * QAMain.secondsTilSend));
 	}
 
 	public static boolean allowGunsInRegion(Location loc) {
@@ -469,7 +469,7 @@ public class QualityArmory {
 		} else if (QAMain.showReloadOnTitle && reloading) {
 			for (int i = 1; i < g.getReloadTime() * 20; i += 2) {
 				final int id = i;
-				new BukkitRunnable() {
+				new FoliaRunnable() {
 					@Override
 					public void run() {
 						StringBuilder sb = new StringBuilder();
@@ -479,7 +479,7 @@ public class QualityArmory {
 						sb.append(repeat("#", (int) (20 - ((int) (20.0 * id / (20 * g.getReloadTime()))))));
 						p.sendTitle(QAMain.S_RELOADING_MESSAGE, sb.toString(), 0, 4, 0);
 					}
-				}.runTaskLater(QAMain.getInstance(), i);
+				}.runTaskLater(QAMain.getInstance(), p, i);
 			}
 		} else {
 

--- a/src/main/java/me/zombie_striker/qg/guns/Gun.java
+++ b/src/main/java/me/zombie_striker/qg/guns/Gun.java
@@ -24,7 +24,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
@@ -1003,7 +1003,7 @@ public class Gun extends CustomBaseObject implements ArmoryBaseObject, Comparabl
 
                         final Gun checkTo = QualityArmory
                                 .getGun(Update19OffhandChecker.getItemStackOFfhand(player.getPlayer()));
-                        new BukkitRunnable() {
+                        new FoliaRunnable() {
 
                             @Override
                             public void run() {
@@ -1030,7 +1030,7 @@ public class Gun extends CustomBaseObject implements ArmoryBaseObject, Comparabl
                                 }
 
                             }
-                        }.runTaskTimer(QAMain.getInstance(), 20, 20);
+                        }.runTaskTimer(QAMain.getInstance(), player, 20, 20);
 
 
                         QualityArmory.sendHotbarGunAmmoCount(player.getPlayer(), this, usedItem, false);

--- a/src/main/java/me/zombie_striker/qg/guns/chargers/BoltactionCharger.java
+++ b/src/main/java/me/zombie_striker/qg/guns/chargers/BoltactionCharger.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 import me.zombie_striker.qg.QAMain;
 import me.zombie_striker.qg.guns.Gun;
@@ -31,7 +31,7 @@ public class BoltactionCharger implements ChargingHandler {
 	@Override
 	public boolean shoot(Gun g, final Player player, ItemStack stack) {
 		timeR.add(player.getUniqueId());
-		new BukkitRunnable() {
+		new FoliaRunnable() {
 			@Override
 			public void run() {
 				try {
@@ -46,8 +46,8 @@ public class BoltactionCharger implements ChargingHandler {
 					}
 				}
 			}
-		}.runTaskLater(QAMain.getInstance(), 10);
-		new BukkitRunnable() {
+		}.runTaskLater(QAMain.getInstance(), player, 10);
+		new FoliaRunnable() {
 			@Override
 			public void run() {
 				try {
@@ -63,7 +63,7 @@ public class BoltactionCharger implements ChargingHandler {
 				}
 				timeR.remove(player.getUniqueId());
 			}
-		}.runTaskLater(QAMain.getInstance(), (int)g.getDelayBetweenShotsInSeconds()*20);
+		}.runTaskLater(QAMain.getInstance(), player, (int)g.getDelayBetweenShotsInSeconds()*20);
 		return true;
 	}
 

--- a/src/main/java/me/zombie_striker/qg/guns/chargers/BreakactionCharger.java
+++ b/src/main/java/me/zombie_striker/qg/guns/chargers/BreakactionCharger.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 import me.zombie_striker.qg.QAMain;
 import me.zombie_striker.qg.guns.Gun;
@@ -30,26 +30,26 @@ public class BreakactionCharger implements ChargingHandler {
 	@Override
 	public boolean shoot(Gun g, final Player player, ItemStack stack) {
 		timeC.add(player.getUniqueId());
-		new BukkitRunnable() {
+		new FoliaRunnable() {
 			@Override
 			public void run() {
 				player.getWorld().playSound(player.getLocation(), g.getChargingSound(), 1, 1f);
 			}
-		}.runTaskLater(QAMain.getInstance(), 10);
-		new BukkitRunnable() {
+		}.runTaskLater(QAMain.getInstance(), player, 10);
+		new FoliaRunnable() {
 
 			@Override
 			public void run() {
 				player.getWorld().playSound(player.getLocation(), g.getChargingSound(), 1, 1f);
 			}
-		}.runTaskLater(QAMain.getInstance(), 15);
-		new BukkitRunnable() {
+		}.runTaskLater(QAMain.getInstance(), player, 15);
+		new FoliaRunnable() {
 
 			@Override
 			public void run() {
 				timeC.remove(player.getUniqueId());
 			}
-		}.runTaskLater(QAMain.getInstance(), (long) (g.getDelayBetweenShotsInSeconds()*20));
+		}.runTaskLater(QAMain.getInstance(), player, (long) (g.getDelayBetweenShotsInSeconds()*20));
 		return true;
 	}
 

--- a/src/main/java/me/zombie_striker/qg/guns/chargers/BurstFireCharger.java
+++ b/src/main/java/me/zombie_striker/qg/guns/chargers/BurstFireCharger.java
@@ -7,7 +7,7 @@ import me.zombie_striker.qg.guns.utils.GunUtil;
 import me.zombie_striker.qg.guns.utils.WeaponSounds;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
 import java.util.HashMap;
@@ -31,7 +31,7 @@ public class BurstFireCharger implements ChargingHandler {
         GunUtil.shootHandler(g, player, 1);
         //	final AttachmentBase attach = QualityArmory.getGunWithAttchments(stack);
         GunUtil.playShoot(g, player);
-        shooters.put(player.getUniqueId(), new BukkitRunnable() {
+        shooters.put(player.getUniqueId(), new FoliaRunnable() {
             final int slotUsed = player.getInventory().getHeldItemSlot();
             @SuppressWarnings("deprecation")
             final boolean offhand = QualityArmory.isIronSights(player.getItemInHand());
@@ -86,7 +86,7 @@ public class BurstFireCharger implements ChargingHandler {
                 }
                 QualityArmory.sendHotbarGunAmmoCount(player, g, stack, false);
             }
-        }.runTaskTimer(QAMain.getInstance(), 10 / g.getFireRate(), 10 / g.getFireRate()));
+        }.runTaskTimer(QAMain.getInstance(), player, 10 / g.getFireRate(), 10 / g.getFireRate()));
         return false;
     }
 

--- a/src/main/java/me/zombie_striker/qg/guns/chargers/DelayedBurstFireCharger.java
+++ b/src/main/java/me/zombie_striker/qg/guns/chargers/DelayedBurstFireCharger.java
@@ -7,7 +7,7 @@ import me.zombie_striker.qg.guns.utils.WeaponSounds;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
 import me.zombie_striker.qg.QAMain;
@@ -33,7 +33,7 @@ public class DelayedBurstFireCharger implements ChargingHandler {
 		GunUtil.shootHandler(g, player);
 		GunUtil.playShoot(g, player);
 
-		shooters.put(player.getUniqueId(), new BukkitRunnable() {
+		shooters.put(player.getUniqueId(), new FoliaRunnable() {
 			int slotUsed = player.getInventory().getHeldItemSlot();
 			@SuppressWarnings("deprecation")
 			boolean offhand = QualityArmory.isIronSights(player.getItemInHand());
@@ -98,7 +98,7 @@ public class DelayedBurstFireCharger implements ChargingHandler {
 				}
 				QualityArmory.sendHotbarGunAmmoCount(player, g, stack, false);
 			}
-		}.runTaskTimer(QAMain.getInstance(), 1, 1));
+		}.runTaskTimer(QAMain.getInstance(), player, 1, 1));
 		return false;
 	}
 

--- a/src/main/java/me/zombie_striker/qg/guns/chargers/PumpactionCharger.java
+++ b/src/main/java/me/zombie_striker/qg/guns/chargers/PumpactionCharger.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 import me.zombie_striker.qg.QAMain;
 import me.zombie_striker.qg.guns.Gun;
@@ -29,7 +29,7 @@ public PumpactionCharger() {
 	public boolean shoot(Gun g, final Player player, ItemStack stack) {
 		timeC.add(player.getUniqueId());
 
-		new BukkitRunnable() {
+		new FoliaRunnable() {
 			@Override
 			public void run() {
 				try {
@@ -46,8 +46,8 @@ public PumpactionCharger() {
 					}catch(Error|Exception e43) {}
 				}
 			}
-		}.runTaskLater(QAMain.getInstance(), 12);
-		new BukkitRunnable() {
+		}.runTaskLater(QAMain.getInstance(), player, 12);
+		new FoliaRunnable() {
 			@Override
 			public void run() {
 				try {
@@ -64,13 +64,13 @@ public PumpactionCharger() {
 
 				}
 			}
-		}.runTaskLater(QAMain.getInstance(), (long) (g.getDelayBetweenShotsInSeconds()*20));
-		new BukkitRunnable() {
+		}.runTaskLater(QAMain.getInstance(), player, (long) (g.getDelayBetweenShotsInSeconds()*20));
+		new FoliaRunnable() {
 			@Override
 			public void run() {
 				timeC.remove(player.getUniqueId());
 			}
-		}.runTaskLater(QAMain.getInstance(), 20);
+		}.runTaskLater(QAMain.getInstance(), player, 20);
 		return true;
 	}
 

--- a/src/main/java/me/zombie_striker/qg/guns/chargers/RevolverCharger.java
+++ b/src/main/java/me/zombie_striker/qg/guns/chargers/RevolverCharger.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 import me.zombie_striker.qg.api.QualityArmory;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 import me.zombie_striker.qg.QAMain;
 import me.zombie_striker.qg.guns.Gun;
@@ -27,7 +27,7 @@ public RevolverCharger() {
 	@Override
 	public boolean shoot(Gun g, final Player player, ItemStack stack) {
 		timeC.add(player.getUniqueId());
-		new BukkitRunnable() {
+		new FoliaRunnable() {
 			@Override
 			public void run() {try {
 				player.getWorld().playSound(player.getLocation(), g.getChargingSound(), 1,
@@ -35,14 +35,14 @@ public RevolverCharger() {
 
 			}catch(Error|Exception e43) {}
 			}
-		}.runTaskLater(QAMain.getInstance(), 10);
-		new BukkitRunnable() {
+		}.runTaskLater(QAMain.getInstance(), player, 10);
+		new FoliaRunnable() {
 			
 			@Override
 			public void run() {
 				timeC.remove(player.getUniqueId());
 			}
-		}.runTaskLater(QAMain.getInstance(), 15);
+		}.runTaskLater(QAMain.getInstance(), player, 15);
 		return true;
 	}
 

--- a/src/main/java/me/zombie_striker/qg/guns/projectiles/ExplodingRoundProjectile.java
+++ b/src/main/java/me/zombie_striker/qg/guns/projectiles/ExplodingRoundProjectile.java
@@ -16,7 +16,7 @@ import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.util.Vector;
 
 public class ExplodingRoundProjectile implements RealtimeCalculationProjectile {
@@ -26,7 +26,7 @@ public class ExplodingRoundProjectile implements RealtimeCalculationProjectile {
 
 	@Override
 	public void spawn(final Gun g, final Location s, final Player player, final Vector dir) {
-		new BukkitRunnable() {
+		new FoliaRunnable() {
 			int distance = g.getMaxDistance();
 
 			@Override
@@ -65,7 +65,7 @@ public class ExplodingRoundProjectile implements RealtimeCalculationProjectile {
 					}
 				}
 			}
-		}.runTaskTimer(QAMain.getInstance(), 0, 1);
+		}.runTaskTimer(QAMain.getInstance(), player, 0, 1);
 	}
 
 	@Override

--- a/src/main/java/me/zombie_striker/qg/guns/projectiles/HomingRocketProjectile.java
+++ b/src/main/java/me/zombie_striker/qg/guns/projectiles/HomingRocketProjectile.java
@@ -18,7 +18,7 @@ import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.util.Vector;
 
 public class HomingRocketProjectile implements RealtimeCalculationProjectile {
@@ -28,7 +28,7 @@ public class HomingRocketProjectile implements RealtimeCalculationProjectile {
 
 	@Override
 	public void spawn(final Gun g, final Location starting, final Player player, final Vector dir) {
-		new BukkitRunnable() {
+		new FoliaRunnable() {
 			Location RPGLOCATION = starting.clone();
 			int distance = g.getMaxDistance();
 			Vector vect = dir;
@@ -90,7 +90,7 @@ public class HomingRocketProjectile implements RealtimeCalculationProjectile {
 					}
 				}
 			}
-		}.runTaskTimer(QAMain.getInstance(), 0, 1);
+		}.runTaskTimer(QAMain.getInstance(), player, 0, 1);
 	}
 
 	@Override

--- a/src/main/java/me/zombie_striker/qg/guns/projectiles/MiniNukeProjectile.java
+++ b/src/main/java/me/zombie_striker/qg/guns/projectiles/MiniNukeProjectile.java
@@ -15,7 +15,7 @@ import me.zombie_striker.qg.handlers.ParticleHandlers;
 import org.bukkit.*;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.util.Vector;
 
 public class MiniNukeProjectile implements RealtimeCalculationProjectile{
@@ -24,7 +24,7 @@ public MiniNukeProjectile() {
 }
 	@Override
 	public void spawn(final Gun g, final Location s, final Player player, final Vector dir) {
-		new BukkitRunnable() {
+		new FoliaRunnable() {
 			int distance = g.getMaxDistance();
 
 			@Override
@@ -60,13 +60,14 @@ public MiniNukeProjectile() {
 						player.getWorld().playSound(s, WeaponSounds.WARHEAD_EXPLODE.getSoundName(), 10, 0.9f);
 						player.getWorld().playSound(s, Sound.ENTITY_GENERIC_EXPLODE, 8, 0.7f);
 						ParticleHandlers.spawnMushroomCloud(s);
-						new BukkitRunnable() {
+						final Location sClone = s.clone();
+						new FoliaRunnable() {
 
 							@Override
 							public void run() {
-								ParticleHandlers.spawnMushroomCloud(s);
+								ParticleHandlers.spawnMushroomCloud(sClone);
 							}
-						}.runTaskLater(QAMain.getInstance(), 10);
+						}.runTaskLater(QAMain.getInstance(), sClone, 10);
 
 					} catch (Error e3) {
 						s.getWorld().playEffect(s, Effect.valueOf("CLOUD"), 0);
@@ -79,7 +80,7 @@ public MiniNukeProjectile() {
 				}
 				
 			}
-		}.runTaskTimer(QAMain.getInstance(), 0, 1);
+		}.runTaskTimer(QAMain.getInstance(), player, 0, 1);
 	}
 	@Override
 	public String getName() {

--- a/src/main/java/me/zombie_striker/qg/guns/projectiles/RocketProjectile.java
+++ b/src/main/java/me/zombie_striker/qg/guns/projectiles/RocketProjectile.java
@@ -14,7 +14,7 @@ import me.zombie_striker.qg.handlers.ParticleHandlers;
 import org.bukkit.*;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.util.Vector;
 
 public class RocketProjectile implements RealtimeCalculationProjectile {
@@ -24,7 +24,7 @@ public class RocketProjectile implements RealtimeCalculationProjectile {
 
 	@Override
 	public void spawn(final Gun g, final Location s, final Player player, final Vector dir) {
-		new BukkitRunnable() {
+		new FoliaRunnable() {
 			int distance = g.getMaxDistance();
 
 			@Override
@@ -68,7 +68,7 @@ public class RocketProjectile implements RealtimeCalculationProjectile {
 					}
 				}
 			}
-		}.runTaskTimer(QAMain.getInstance(), 0, 1);
+		}.runTaskTimer(QAMain.getInstance(), player, 0, 1);
 	}
 
 	@Override

--- a/src/main/java/me/zombie_striker/qg/guns/reloaders/M1GarandReloader.java
+++ b/src/main/java/me/zombie_striker/qg/guns/reloaders/M1GarandReloader.java
@@ -4,7 +4,7 @@ import me.zombie_striker.qg.QAMain;
 import me.zombie_striker.qg.guns.Gun;
 import me.zombie_striker.qg.guns.utils.WeaponSounds;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,13 +27,13 @@ public class M1GarandReloader implements ReloadingHandler{
 	public double reload(Player player, Gun g, int amountReloading) {
 		timeR.add(player.getUniqueId());
 		player.getWorld().playSound(player.getLocation(), WeaponSounds.RELOAD_CLICK.getSoundName(), 1, 1f);
-			new BukkitRunnable() {
+			new FoliaRunnable() {
 				@Override
 				public void run() {
 						player.getWorld().playSound(player.getLocation(), g.getReloadingSound(), 1, 1f);
 						timeR.remove(player.getUniqueId());
 				}
-			}.runTaskLater(QAMain.getInstance(), Math.max((int) ((g.getReloadTime()* 20.0) - 10.0),10));
+			}.runTaskLater(QAMain.getInstance(), player, Math.max((int) ((g.getReloadTime()* 20.0) - 10.0),10));
 		return g.getReloadTime();
 	}
 

--- a/src/main/java/me/zombie_striker/qg/guns/reloaders/PumpactionReloader.java
+++ b/src/main/java/me/zombie_striker/qg/guns/reloaders/PumpactionReloader.java
@@ -8,7 +8,7 @@ import me.zombie_striker.qg.api.QualityArmory;
 import me.zombie_striker.qg.guns.utils.WeaponSounds;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 import me.zombie_striker.qg.QAMain;
 import me.zombie_striker.qg.guns.Gun;
@@ -34,7 +34,7 @@ public class PumpactionReloader implements ReloadingHandler {
 		for (int i = 0; i < amountReloading; i++) {
 			final boolean k = (i + 1 == amountReloading);
 			final int finalI = i;
-			new BukkitRunnable() {
+			new FoliaRunnable() {
 				int temp = player.getInventory().getHeldItemSlot();
 
 				@Override
@@ -61,15 +61,15 @@ public class PumpactionReloader implements ReloadingHandler {
 						}
 					}
 				}
-			}.runTaskLater(QAMain.getInstance(), (int) (time * i * 20));
+			}.runTaskLater(QAMain.getInstance(), player, (int) (time * i * 20));
 		}
-		new BukkitRunnable() {
+		new FoliaRunnable() {
 			@Override
 			public void run() {
 				timeR.remove(player.getUniqueId());
 
 			}
-		}.runTaskLater(QAMain.getInstance(), (int) (time2 * 20) + 5);
+		}.runTaskLater(QAMain.getInstance(), player, (int) (time2 * 20) + 5);
 		return time2;
 	}
 

--- a/src/main/java/me/zombie_striker/qg/guns/reloaders/SingleBulletReloader.java
+++ b/src/main/java/me/zombie_striker/qg/guns/reloaders/SingleBulletReloader.java
@@ -8,7 +8,7 @@ import me.zombie_striker.qg.api.QualityArmory;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 import me.zombie_striker.qg.QAMain;
 import me.zombie_striker.qg.guns.Gun;
@@ -34,7 +34,7 @@ public class SingleBulletReloader implements ReloadingHandler {
 		double time2 = time * amountReloading;
 		for (int i = 0; i < amountReloading; i++) {
 			final int finalI = i;
-			new BukkitRunnable() {
+			new FoliaRunnable() {
 				int temp = player.getInventory().getHeldItemSlot();
 				@Override
 				public void run() {
@@ -51,15 +51,15 @@ public class SingleBulletReloader implements ReloadingHandler {
 						}
 					}
 				}
-			}.runTaskLater(QAMain.getInstance(), (int) (time * i * 20));
+			}.runTaskLater(QAMain.getInstance(), player, (int) (time * i * 20));
 		}
-		new BukkitRunnable() {
+		new FoliaRunnable() {
 			@Override
 			public void run() {
 				timeR.remove(player.getUniqueId());
 
 			}
-		}.runTaskLater(QAMain.getInstance(), (int) (time2 * 20) + 5);
+		}.runTaskLater(QAMain.getInstance(), player, (int) (time2 * 20) + 5);
 		return time2;
 	}
 

--- a/src/main/java/me/zombie_striker/qg/guns/reloaders/SlideReloader.java
+++ b/src/main/java/me/zombie_striker/qg/guns/reloaders/SlideReloader.java
@@ -4,7 +4,7 @@ import me.zombie_striker.qg.QAMain;
 import me.zombie_striker.qg.guns.Gun;
 import me.zombie_striker.qg.guns.utils.WeaponSounds;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,13 +27,13 @@ public class SlideReloader implements ReloadingHandler{
 	public double reload(Player player, Gun g, int amountReloading) {
 		timeR.add(player.getUniqueId());
 		player.getWorld().playSound(player.getLocation(), WeaponSounds.RELOAD_CLICK.getSoundName(), 1, 1f);
-			new BukkitRunnable() {
+			new FoliaRunnable() {
 				@Override
 				public void run() {
 						player.getWorld().playSound(player.getLocation(), g.getReloadingSound(), 1, 1f);
 						timeR.remove(player.getUniqueId());
 				}
-			}.runTaskLater(QAMain.getInstance(), Math.max((int) ((g.getReloadTime()* 20.0) - 10.0),10));
+			}.runTaskLater(QAMain.getInstance(), player, Math.max((int) ((g.getReloadTime()* 20.0) - 10.0),10));
 		return g.getReloadTime();
 	}
 

--- a/src/main/java/me/zombie_striker/qg/guns/utils/GunRefillerRunnable.java
+++ b/src/main/java/me/zombie_striker/qg/guns/utils/GunRefillerRunnable.java
@@ -13,7 +13,7 @@ import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
 import java.util.ArrayList;
@@ -78,7 +78,7 @@ public class GunRefillerRunnable {
 
         this.reloadedItem = modifiedOriginalItem.clone();
 
-        r = new BukkitRunnable() {
+        r = new FoliaRunnable() {
             @Override
             public void run() {
                 ItemMeta newim = modifiedOriginalItem.getItemMeta();
@@ -168,7 +168,7 @@ public class GunRefillerRunnable {
                     QAMain.reloadingTasks.put(player.getUniqueId(), rr);
                 }
             }
-        }.runTaskLater(QAMain.getInstance(), (long) (20 * seconds));
+        }.runTaskLater(QAMain.getInstance(), player, (long) (20 * seconds));
 
         allGunRefillers.add(gg);
 

--- a/src/main/java/me/zombie_striker/qg/guns/utils/GunUtil.java
+++ b/src/main/java/me/zombie_striker/qg/guns/utils/GunUtil.java
@@ -26,7 +26,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.*;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
@@ -419,7 +419,8 @@ public class GunUtil {
 
 				if (QAMain.regenDestructableBlocksAfter > 0) {
 					QAMain.DEBUG("Scheduling replacement of " + regenBlocks.size() + " blocks");
-					new BukkitRunnable() {
+					final Location regenLoc = start.clone();
+					new FoliaRunnable() {
 						@Override
 						public void run() {
 							QAMain.DEBUG("Replacing " + regenBlocks.size() + " blocks");
@@ -429,7 +430,7 @@ public class GunUtil {
 								CoreProtectHook.logPlace(l,p);
 							}
 						}
-					}.runTaskLater(QAMain.getInstance(), QAMain.regenDestructableBlocksAfter * 20L);
+					}.runTaskLater(QAMain.getInstance(), regenLoc, QAMain.regenDestructableBlocksAfter * 20L);
 				}
 			}
 
@@ -440,13 +441,13 @@ public class GunUtil {
 					if (p.getEyeLocation().getBlock().getLightLevel() < g.getLightOnShoot()) {
 						final Location loc = p.getEyeLocation().clone();
 						LightAPI.get().setLightLevel(loc.getWorld().getName(),loc.getBlockX(),loc.getBlockY(),loc.getBlockZ(), g.getLightOnShoot());
-						new BukkitRunnable() {
+						new FoliaRunnable() {
 
 							@Override
 							public void run() {
 								LightAPI.get().setLightLevel(loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ(), 0);
 							}
-						}.runTaskLater(QAMain.getInstance(), 3);
+						}.runTaskLater(QAMain.getInstance(), loc, 3);
 					}
 				}
 			} catch (Error | Exception e5) {
@@ -532,7 +533,7 @@ public class GunUtil {
 		}
 
 		if (g.isAutomatic()) {
-			rapidfireshooters.put(player.getUniqueId(), new BukkitRunnable() {
+			rapidfireshooters.put(player.getUniqueId(), new FoliaRunnable() {
 				int slotUsed = player.getInventory().getHeldItemSlot();
 
 				@Override
@@ -653,7 +654,7 @@ public class GunUtil {
 					}
 					QualityArmory.sendHotbarGunAmmoCount(player, g, temp, false);
 				}
-			}.runTaskTimer(QAMain.getInstance(), 10 / g.getFireRate(), 10 / g.getFireRate()));
+			}.runTaskTimer(QAMain.getInstance(), player, 10 / g.getFireRate(), 10 / g.getFireRate()));
 		}
 
 		int amount = Gun.getAmount(player) - 1;
@@ -708,7 +709,7 @@ public class GunUtil {
 
 	public static void playShoot(final Gun g, final Player player) {
 		g.damageDurability(player);
-		new BukkitRunnable() {
+		new FoliaRunnable() {
 			@SuppressWarnings("deprecation")
 			@Override
 			public void run() {
@@ -737,7 +738,7 @@ public class GunUtil {
 				}
 
 			}
-		}.runTaskLater(QAMain.getInstance(), 1);
+		}.runTaskLater(QAMain.getInstance(), player, 1);
 		// Simply delaying the sound by 1/20th of a second makes shooting so much more
 		// immersive
 	}
@@ -808,7 +809,7 @@ public class GunUtil {
 						highRecoilCounter.get(player.getUniqueId()) + g.getRecoil());
 			} else {
 				highRecoilCounter.put(player.getUniqueId(), g.getRecoil());
-				new BukkitRunnable() {
+				new FoliaRunnable() {
 					@Override
 					public void run() {
 						if (QAMain.hasProtocolLib && QAMain.isVersionHigherThan(1, 13) && !QAMain.hasViaVersion) {
@@ -816,7 +817,7 @@ public class GunUtil {
 						} else
 							addRecoilWithTeleport(player, g, true);
 					}
-				}.runTaskLater(QAMain.getInstance(), 3);
+				}.runTaskLater(QAMain.getInstance(), player, 3);
 			}
 		} else {
 			if (QAMain.hasProtocolLib && QAMain.isVersionHigherThan(1, 13)) {

--- a/src/main/java/me/zombie_striker/qg/handlers/AimManager.java
+++ b/src/main/java/me/zombie_striker/qg/handlers/AimManager.java
@@ -9,14 +9,14 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-public class AimManager extends BukkitRunnable implements Listener {
+public class AimManager extends FoliaRunnable implements Listener {
 	private static final Map<UUID, Double> SWAYS = new HashMap<>();
 	private static final Map<UUID, Long> LAST_MOVEMENT = new HashMap<>();
 

--- a/src/main/java/me/zombie_striker/qg/handlers/BulletWoundHandler.java
+++ b/src/main/java/me/zombie_striker/qg/handlers/BulletWoundHandler.java
@@ -9,7 +9,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
 import me.zombie_striker.qg.QAMain;
@@ -39,53 +39,56 @@ public class BulletWoundHandler {
 
 	public static void startTimer() {
 		if (QAMain.enableBleeding) {
-			task = new BukkitRunnable() {
+			task = new FoliaRunnable() {
 				@Override
 				public void run() {
-					for (Entry<UUID, Double> e : bleedoutMultiplier.entrySet()) {
+					for (Entry<UUID, Double> e : new HashMap<>(bleedoutMultiplier).entrySet()) {
 						Player online = Bukkit.getPlayer(e.getKey());
 						if (online != null) {
-							if (!bloodLevel.containsKey(online.getUniqueId()))
-								bloodLevel.put(online.getUniqueId(), 0.0);
-							double bloodlevel = bloodLevel.get(online.getUniqueId()) + e.getValue()
-									+ QAMain.bulletWound_BloodIncreasePerSecond;
-
-							if (bloodlevel / QAMain.bulletWound_initialbloodamount <= 0.75)
-
-								try {
-									online.removePotionEffect(XPotion.NAUSEA.getPotionEffectType());
-									online.addPotionEffect(new PotionEffect(XPotion.NAUSEA.getPotionEffectType(), 499, 3));
-								} catch (Error | Exception e4) {
-								}
-							if (bloodlevel / QAMain.bulletWound_initialbloodamount <= 0.40)
-								try {
-									online.removePotionEffect(PotionEffectType.BLINDNESS);
-									online.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 499, 1));
-								} catch (Error | Exception e4) {
-								}
-							if (bloodlevel / QAMain.bulletWound_initialbloodamount == 0.0)
-								online.damage(1);
-							if (bleedoutMultiplier.get(online.getUniqueId()) < 0)
-								// online.getWorld().spawnParticle(Particle.REDSTONE,
-								// online.getLocation().getX(), online.getLocation().getY()+1.5,
-								// online.getLocation().getZ(), 0, 1.0, 0.0, 0.0, 1);
-								for (int i = 0; i < 5; i++) {
-									double x = Math.random() - 0.5;
-									double z = Math.random() - 0.5;
-									double yofset = Math.random();
-									ParticleHandlers.spawnParticle(1, 0, 0,
-											online.getLocation().add(x, 0.8 + yofset, z));
-								}
-
-							if (bloodlevel >= QAMain.bulletWound_initialbloodamount)
-								bloodLevel.remove(online.getUniqueId());
-							else
-								bloodLevel.put(online.getUniqueId(), bloodlevel);
+							final Player p = online;
+							FoliaRunnable.runEntityTask(QAMain.getInstance(), p, () -> applyBleedEffect(p));
 						}
 					}
 				}
-			}.runTaskTimer(QAMain.getInstance(), 0, 20);
+			}.runTaskTimerAsynchronously(QAMain.getInstance(), 0, 20);
 		}
+	}
+
+	private static void applyBleedEffect(Player online) {
+		if (!bleedoutMultiplier.containsKey(online.getUniqueId())) return;
+		if (!bloodLevel.containsKey(online.getUniqueId()))
+			bloodLevel.put(online.getUniqueId(), 0.0);
+		double bleedMult = bleedoutMultiplier.get(online.getUniqueId());
+		double bloodlevel = bloodLevel.get(online.getUniqueId()) + bleedMult
+				+ QAMain.bulletWound_BloodIncreasePerSecond;
+
+		if (bloodlevel / QAMain.bulletWound_initialbloodamount <= 0.75)
+			try {
+				online.removePotionEffect(XPotion.NAUSEA.getPotionEffectType());
+				online.addPotionEffect(new PotionEffect(XPotion.NAUSEA.getPotionEffectType(), 499, 3));
+			} catch (Error | Exception e4) {
+			}
+		if (bloodlevel / QAMain.bulletWound_initialbloodamount <= 0.40)
+			try {
+				online.removePotionEffect(PotionEffectType.BLINDNESS);
+				online.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 499, 1));
+			} catch (Error | Exception e4) {
+			}
+		if (bloodlevel / QAMain.bulletWound_initialbloodamount == 0.0)
+			online.damage(1);
+		if (bleedMult < 0)
+			for (int i = 0; i < 5; i++) {
+				double x = Math.random() - 0.5;
+				double z = Math.random() - 0.5;
+				double yofset = Math.random();
+				ParticleHandlers.spawnParticle(1, 0, 0,
+						online.getLocation().add(x, 0.8 + yofset, z));
+			}
+
+		if (bloodlevel >= QAMain.bulletWound_initialbloodamount)
+			bloodLevel.remove(online.getUniqueId());
+		else
+			bloodLevel.put(online.getUniqueId(), bloodlevel);
 	}
 
 }

--- a/src/main/java/me/zombie_striker/qg/handlers/ParticleHandlers.java
+++ b/src/main/java/me/zombie_striker/qg/handlers/ParticleHandlers.java
@@ -9,7 +9,7 @@ import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import ru.beykerykt.minecraft.lightapi.common.LightAPI;
 
 public class ParticleHandlers {
@@ -30,12 +30,12 @@ public class ParticleHandlers {
 			if (Bukkit.getPluginManager().getPlugin("LightAPI") != null) {
 				final Location loc2 = loc;
 				LightAPI.get().setLightLevel(loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ(), 15);
-				new BukkitRunnable() {
+				new FoliaRunnable() {
 					@Override
 					public void run() {
 						LightAPI.get().setLightLevel(loc2.getWorld().getName(), loc2.getBlockX(), loc2.getBlockY(), loc2.getBlockZ(), 0);
 					}
-				}.runTaskLater(QAMain.getInstance(), 10);
+				}.runTaskLater(QAMain.getInstance(), loc2, 10);
 			}
 		} catch (Error | Exception e5) {
 		}
@@ -89,13 +89,13 @@ public class ParticleHandlers {
 			if (Bukkit.getPluginManager().getPlugin("LightAPI") != null) {
 				final Location loc2 = loc;
 				LightAPI.get().setLightLevel(loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ(), 15);
-				new BukkitRunnable() {
+				new FoliaRunnable() {
 
 					@Override
 					public void run() {
 						LightAPI.get().setLightLevel(loc2.getWorld().getName(), loc2.getBlockX(), loc2.getBlockY(), loc2.getBlockZ(), 0);
 					}
-				}.runTaskLater(QAMain.getInstance(), 20);
+				}.runTaskLater(QAMain.getInstance(), loc2, 20);
 			}
 		} catch (Error | Exception e5) {
 		}

--- a/src/main/java/me/zombie_striker/qg/handlers/ProtocolLibHandler.java
+++ b/src/main/java/me/zombie_striker/qg/handlers/ProtocolLibHandler.java
@@ -20,7 +20,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.CrossbowMeta;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
@@ -213,8 +213,9 @@ public class ProtocolLibHandler {
 
                         // Schedule task to send offhand packet
                         final ItemStack finalItemStack = itemStack;
+                        final Player packetPlayer = event.getPlayer();
 
-                        new BukkitRunnable() {
+                        new FoliaRunnable() {
                             public void run() {
                                 try {
                                     PacketContainer pc2 = protocolManager.createPacket(PacketType.Play.Server.ENTITY_EQUIPMENT);
@@ -223,13 +224,13 @@ public class ProtocolLibHandler {
                                     pc2.getItemSlots().write(1, slot);
                                     pc2.getItemModifier().write(2, finalItemStack);
 
-                                    protocolManager.sendServerPacket(event.getPlayer(), pc2);
+                                    protocolManager.sendServerPacket(packetPlayer, pc2);
                                 } catch (Exception e) {
                                     QAMain.DEBUG("Error sending offhand packet: " + e.getMessage());
                                     e.printStackTrace();
                                 }
                             }
-                        }.runTaskLater(QAMain.getInstance(), 1);
+                        }.runTaskLater(QAMain.getInstance(), packetPlayer, 1);
                     }
 
                     /**

--- a/src/main/java/me/zombie_striker/qg/handlers/Update19resourcepackhandler.java
+++ b/src/main/java/me/zombie_striker/qg/handlers/Update19resourcepackhandler.java
@@ -1,7 +1,7 @@
 package me.zombie_striker.qg.handlers;
 
 import me.zombie_striker.qg.QAMain;
-import org.bukkit.Bukkit;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -24,7 +24,7 @@ public class Update19resourcepackhandler implements Listener {
 
         if (event.getStatus() == PlayerResourcePackStatusEvent.Status.DECLINED) {
             if (QAMain.kickIfDeniedRequest) {
-                Bukkit.getScheduler().runTask(QAMain.getInstance(), () -> event.getPlayer().kickPlayer(QAMain.S_KICKED_FOR_RESOURCEPACK));
+                FoliaRunnable.runTask(QAMain.getInstance(), () -> event.getPlayer().kickPlayer(QAMain.S_KICKED_FOR_RESOURCEPACK));
             }
 
             // Add to the list, so it doesn't keep spamming the title

--- a/src/main/java/me/zombie_striker/qg/listener/QAListener.java
+++ b/src/main/java/me/zombie_striker/qg/listener/QAListener.java
@@ -41,7 +41,7 @@ import org.bukkit.event.player.*;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.scoreboard.Scoreboard;
 
 import java.util.ArrayList;
@@ -92,7 +92,7 @@ public class QAListener implements Listener {
 					QAMain.DEBUG("Detected interact on entity, running LMB for " + g.getName());
 
 					Gun finalG = g;
-					Bukkit.getScheduler().runTaskLater(QAMain.getInstance(), () -> {
+					FoliaRunnable.runEntityTaskLater(QAMain.getInstance(), d, () -> {
 						finalG.onLMB(d, d.getItemInHand());
 						ignoreClick.remove(d.getUniqueId());
 					}, 1L);
@@ -169,7 +169,7 @@ public class QAListener implements Listener {
 									return;
 
 								IronsightsHandler.aim(e.getPlayer());
-								new BukkitRunnable() {
+								new FoliaRunnable() {
 									@Override
 									public void run() {
 										MaterialStorage ms1 = MaterialStorage.getMS(e.getPlayer().getItemInHand());
@@ -179,7 +179,7 @@ public class QAListener implements Listener {
 											DEBUG("Item Duped. Got Rid of using offhand override (code=1)");
 										}
 									}
-								}.runTaskLater(QAMain.getInstance(), 1);
+								}.runTaskLater(QAMain.getInstance(), e.getPlayer(), 1);
 							} catch (Error e2) {
 								Bukkit.broadcastMessage(QAMain.prefix
 										+ "Ironsights not compatible for versions lower than 1.8. The server owner should set EnableIronSights to false in the plugin's config");
@@ -188,7 +188,7 @@ public class QAListener implements Listener {
 					}
 				} else {
 					if (IronsightsHandler.isAiming(e.getPlayer())) {
-						new BukkitRunnable() {
+						new FoliaRunnable() {
 
 							@Override
 							public void run() {
@@ -200,7 +200,7 @@ public class QAListener implements Listener {
 									DEBUG("Item Duped. Got Rid of using offhand override (code=2)");
 								}
 							}
-						}.runTaskLater(QAMain.getInstance(), 5);
+						}.runTaskLater(QAMain.getInstance(), e.getPlayer(), 5);
 
 						IronsightsHandler.unAim(e.getPlayer());
 						QAMain.DEBUG("Swap gun back to main hand");
@@ -245,13 +245,13 @@ public class QAListener implements Listener {
 				} else {
 					t = Gun.removeCalculatedExtra(hand);
 				}
-				new BukkitRunnable() {
+				new FoliaRunnable() {
 
 					@Override
 					public void run() {
 						e.getPlayer().setItemInHand(t);
 					}
-				}.runTaskLater(QAMain.getInstance(), 1);
+				}.runTaskLater(QAMain.getInstance(), e.getPlayer(), 1);
 
 			}
 	}
@@ -268,7 +268,7 @@ public class QAListener implements Listener {
 
 			if (!ignoreDropReload.contains(uuid)) {
 				ignoreDropReload.add(uuid);
-				Bukkit.getScheduler().runTaskLater(QAMain.getInstance(), () -> ignoreDropReload.remove(uuid), 2L);
+				FoliaRunnable.runTaskLater(QAMain.getInstance(), () -> ignoreDropReload.remove(uuid), 2L);
 			}
 
 			return;
@@ -495,7 +495,7 @@ public class QAListener implements Listener {
 
 			ignoreClick.add(e.getPlayer().getUniqueId());
 
-			Bukkit.getScheduler().runTaskLater(QAMain.getInstance(), () -> {
+			FoliaRunnable.runEntityTaskLater(QAMain.getInstance(), e.getPlayer(), () -> {
 				ignoreClick.remove(e.getPlayer().getUniqueId());
 
 				if (e.getPlayer().isSneaking()) unloadAll(e.getPlayer(), finalG);
@@ -506,7 +506,7 @@ public class QAListener implements Listener {
 			
 			ignoreClick.add(e.getPlayer().getUniqueId());
 
-			Bukkit.getScheduler().runTaskLater(QAMain.getInstance(), () -> {
+			FoliaRunnable.runEntityTaskLater(QAMain.getInstance(), e.getPlayer(), () -> {
 				ignoreClick.remove(e.getPlayer().getUniqueId());
 				reload(e.getPlayer(), finalG);
 			}, 2L);
@@ -860,7 +860,7 @@ public class QAListener implements Listener {
 				}
 				final ItemStack temp2 = temp1;
 
-				new BukkitRunnable() {
+				new FoliaRunnable() {
 					@Override
 					public void run() {
 						if (origin.getDurability() != e.getPlayer().getItemInHand().getDurability()
@@ -883,7 +883,7 @@ public class QAListener implements Listener {
 						}
 
 					}
-				}.runTaskLater(QAMain.getInstance(), 0);
+				}.runTaskLater(QAMain.getInstance(), e.getPlayer(), 0);
 			}
 
 			ItemStack usedItem = IronsightsHandler.getItemAiming(e.getPlayer());
@@ -960,7 +960,7 @@ public class QAListener implements Listener {
 			e.setCancelled(true);
 			ignoreClick.add(healer.getUniqueId());
 
-			Bukkit.getScheduler().runTaskLater(QAMain.getInstance(), () -> ignoreClick.remove(healer.getUniqueId()), 2L);
+			FoliaRunnable.runTaskLater(QAMain.getInstance(), () -> ignoreClick.remove(healer.getUniqueId()), 2L);
 		}
 	}
 
@@ -993,7 +993,7 @@ public class QAListener implements Listener {
 			}
 
 			if (customBase instanceof Gun && e.getPlayer().isSneaking() && ((Gun) customBase).hasIronSights()) {
-				Bukkit.getScheduler().runTaskLater(QAMain.getInstance(), () -> IronsightsHandler.aim(e.getPlayer()), 1);
+				FoliaRunnable.runEntityTaskLater(QAMain.getInstance(), e.getPlayer(), () -> IronsightsHandler.aim(e.getPlayer()), 1);
 			}
 
 			QAMain.lastWeaponSwitch.put(e.getPlayer().getUniqueId(), System.currentTimeMillis());
@@ -1045,7 +1045,7 @@ public class QAListener implements Listener {
 			}
 		}
 		if (QAMain.addGlowEffects) {
-			new BukkitRunnable() {
+			new FoliaRunnable() {
 
 				@Override
 				public void run() {
@@ -1054,7 +1054,7 @@ public class QAListener implements Listener {
 						QAMain.coloredGunScoreboard.add(QAMain.registerGlowTeams(e.getPlayer().getScoreboard()));
 					}
 				}
-			}.runTaskLater(QAMain.getInstance(), 20 * 15);
+			}.runTaskLater(QAMain.getInstance(), e.getPlayer(), 20 * 15);
 		}
 
 		if (QAMain.shouldSend && QAMain.sendOnJoin) {
@@ -1063,14 +1063,14 @@ public class QAListener implements Listener {
 			for (ItemStack i : e.getPlayer().getInventory().getContents()) {
 				if (i != null && (QualityArmory.isGun(i) || QualityArmory.isAmmo(i) || QualityArmory.isMisc(i))) {
 					if (QAMain.shouldSend && !QAMain.resourcepackReq.contains(e.getPlayer().getUniqueId())) {
-						new BukkitRunnable() {
+						new FoliaRunnable() {
 
 							@Override
 							public void run() {
 								QualityArmory.sendResourcepack(e.getPlayer(), false);
 							}
 
-						}.runTaskLater(QAMain.getInstance(), 0);
+						}.runTaskLater(QAMain.getInstance(), e.getPlayer(), 0);
 					}
 					break;
 				}
@@ -1136,13 +1136,13 @@ public class QAListener implements Listener {
 								e.setCancelled(true);
 
 								final Gun gk = g;
-								new BukkitRunnable() {
+								new FoliaRunnable() {
 									@Override
 									public void run() {
 										QAMain.DEBUG("Reloaded after one tick");
 										GunUtil.basicReload(gk, e.getPlayer(), gk.hasUnlimitedAmmo());
 									}
-								}.runTaskLater(QAMain.getInstance(), 1);
+								}.runTaskLater(QAMain.getInstance(), e.getPlayer(), 1);
 							}
 						}
 

--- a/src/main/java/me/zombie_striker/qg/miscitems/Flashbang.java
+++ b/src/main/java/me/zombie_striker/qg/miscitems/Flashbang.java
@@ -12,7 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 import me.zombie_striker.qg.QAMain;
 import me.zombie_striker.customitemmanager.MaterialStorage;
@@ -37,7 +37,7 @@ public class Flashbang extends Grenade {
 		}
 		thrower.getWorld().playSound(thrower.getLocation(), WeaponSounds.RELOAD_MAG_IN.getSoundName(), 2, 1);
 		final ThrowableHolder h = new ThrowableHolder(thrower.getUniqueId(), thrower, this);
-		h.setTimer(new BukkitRunnable() {
+		h.setTimer(new FoliaRunnable() {
 			@Override
 			public void run() {
 				try {
@@ -72,7 +72,7 @@ public class Flashbang extends Grenade {
 
 				throwItems.remove(h.getHolder());
 			}
-		}.runTaskLater(QAMain.getInstance(), 5 * 20));
+		}.runTaskLater(QAMain.getInstance(), thrower.getLocation().clone(), 5 * 20));
 		throwItems.put(thrower, h);
 		return true;
 	}

--- a/src/main/java/me/zombie_striker/qg/miscitems/Grenade.java
+++ b/src/main/java/me/zombie_striker/qg/miscitems/Grenade.java
@@ -18,7 +18,7 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.Nullable;
 
@@ -120,7 +120,7 @@ public class Grenade extends CustomBaseObject implements ThrowableItems {
 
 		thrower.getWorld().playSound(thrower.getLocation(), WeaponSounds.RELOAD_MAG_IN.getSoundName(), 2, 1);
 		final ThrowableHolder h = new ThrowableHolder(thrower.getUniqueId(), thrower, this);
-		h.setTimer(new BukkitRunnable() {
+		h.setTimer(new FoliaRunnable() {
 			@Override
 			public void run() {
 				if (h.getHolder() instanceof Player) {
@@ -165,7 +165,7 @@ public class Grenade extends CustomBaseObject implements ThrowableItems {
 				}
 				throwItems.remove(h.getHolder());
 			}
-		}.runTaskLater(QAMain.getInstance(), 5 * 20));
+		}.runTaskLater(QAMain.getInstance(), thrower.getLocation().clone(), 5 * 20));
 		throwItems.put(thrower, h);
 		return true;
 	}

--- a/src/main/java/me/zombie_striker/qg/miscitems/IncendaryGrenades.java
+++ b/src/main/java/me/zombie_striker/qg/miscitems/IncendaryGrenades.java
@@ -11,7 +11,7 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 import me.zombie_striker.qg.QAMain;
 import me.zombie_striker.customitemmanager.MaterialStorage;
@@ -35,7 +35,7 @@ public class IncendaryGrenades extends Grenade {
 		}
 		thrower.getWorld().playSound(thrower.getLocation(), WeaponSounds.RELOAD_MAG_IN.getSoundName(), 2, 1);
 		final ThrowableHolder h = new ThrowableHolder(thrower.getUniqueId(), thrower, this);
-		h.setTimer(new BukkitRunnable() {
+		h.setTimer(new FoliaRunnable() {
 
 			int k = 0;
 
@@ -83,7 +83,7 @@ public class IncendaryGrenades extends Grenade {
 						}
 				}
 			}
-		}.runTaskTimer(QAMain.getInstance(),5*20,10));
+		}.runTaskTimer(QAMain.getInstance(), thrower.getLocation().clone(), 5*20, 10));
 		throwItems.put(thrower, h);
 
 		return true;

--- a/src/main/java/me/zombie_striker/qg/miscitems/Molotov.java
+++ b/src/main/java/me/zombie_striker/qg/miscitems/Molotov.java
@@ -12,7 +12,7 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 import java.util.List;
 
@@ -34,7 +34,7 @@ public class Molotov extends Grenade {
 		}
 		thrower.getWorld().playSound(thrower.getLocation(), WeaponSounds.RELOAD_MAG_IN.getSoundName(), 2, 1);
 		final ThrowableHolder h = new ThrowableHolder(thrower.getUniqueId(), thrower, this);
-		h.setTimer(new BukkitRunnable() {
+		h.setTimer(new FoliaRunnable() {
 
 			int k = 0;
 
@@ -81,7 +81,7 @@ public class Molotov extends Grenade {
 						}
 				}
 			}
-		}.runTaskTimer(QAMain.getInstance(),5*20,10));
+		}.runTaskTimer(QAMain.getInstance(), thrower.getLocation().clone(), 5*20, 10));
 		throwItems.put(thrower, h);
 
 		return true;

--- a/src/main/java/me/zombie_striker/qg/miscitems/ProxyMines.java
+++ b/src/main/java/me/zombie_striker/qg/miscitems/ProxyMines.java
@@ -15,7 +15,7 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 import org.bukkit.util.Vector;
 
 import java.util.List;
@@ -37,7 +37,7 @@ public class ProxyMines extends Grenade {
 		}
 		thrower.getWorld().playSound(thrower.getLocation(), WeaponSounds.RELOAD_MAG_IN.getSoundName(), 2, 1);
 		final ThrowableHolder h = new ThrowableHolder(thrower.getUniqueId(), thrower, this);
-		h.setTimer(new BukkitRunnable() {
+		h.setTimer(new FoliaRunnable() {
 
 			int k = 0;
 			BlockFace sticky = null;
@@ -111,7 +111,7 @@ public class ProxyMines extends Grenade {
 					}
 				}
 			}
-		}.runTaskTimer(QAMain.getInstance(), 5, 1));
+		}.runTaskTimer(QAMain.getInstance(), thrower.getLocation().clone(), 5, 1));
 		throwItems.put(thrower, h);
 		return true;
 	}

--- a/src/main/java/me/zombie_striker/qg/miscitems/SmokeGrenades.java
+++ b/src/main/java/me/zombie_striker/qg/miscitems/SmokeGrenades.java
@@ -14,7 +14,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 import me.zombie_striker.qg.QAMain;
 import me.zombie_striker.customitemmanager.MaterialStorage;
@@ -38,7 +38,7 @@ public class SmokeGrenades extends Grenade {
             }
 		thrower.getWorld().playSound(thrower.getLocation(), WeaponSounds.RELOAD_MAG_IN.getSoundName(), 2, 1);
 		final ThrowableHolder h = new ThrowableHolder(thrower.getUniqueId(), thrower, this);
-		h.setTimer(new BukkitRunnable() {
+		h.setTimer(new FoliaRunnable() {
 
 			int k = 0;
 
@@ -134,7 +134,7 @@ public class SmokeGrenades extends Grenade {
 						}
 				}
 			}
-		}.runTaskTimer(QAMain.getInstance(), 5 * 20, 5));
+		}.runTaskTimer(QAMain.getInstance(), thrower.getLocation().clone(), 5 * 20, 5));
 		throwItems.put(thrower, h);
 		return true;
 

--- a/src/main/java/me/zombie_striker/qg/miscitems/StickyGrenades.java
+++ b/src/main/java/me/zombie_striker/qg/miscitems/StickyGrenades.java
@@ -11,7 +11,7 @@ import org.bukkit.GameMode;
 import org.bukkit.Sound;
 import org.bukkit.entity.*;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.zombie_striker.qg.util.FoliaRunnable;
 
 import java.util.List;
 
@@ -45,7 +45,7 @@ public class StickyGrenades extends Grenade {
 			holder.setHolder(arrow);
 			arrow.setPickupStatus(AbstractArrow.PickupStatus.DISALLOWED);
 			throwItems.put(holder.getHolder(),holder);
-			holder.setTimer(new BukkitRunnable(){
+			holder.setTimer(new FoliaRunnable(){
 				public void run(){
 					if(thrower.isSneaking()) {
 						if (holder.getHolder() instanceof Arrow) {
@@ -86,7 +86,7 @@ public class StickyGrenades extends Grenade {
 						this.cancel();
 					}
 				}
-			}.runTaskTimer(QAMain.getInstance(),0,2));
+			}.runTaskTimer(QAMain.getInstance(), thrower.getLocation().clone(), 0, 2));
 			//thrower.getWorld().playSound(thrower.getLocation(), Sound.ENTITY_ARROW_SHOOT, 1, 1.5f);
 
 			QAMain.DEBUG("Throw grenade");

--- a/src/main/java/me/zombie_striker/qg/npcs/Gunner.java
+++ b/src/main/java/me/zombie_striker/qg/npcs/Gunner.java
@@ -27,7 +27,7 @@ public class Gunner {
 		SkinnableEntity se = ((SkinnableEntity)gunner.gunner.getEntity());
 		se.setSkinName("army");
 		// gunner.gunner.addTrait(GunnerTrait.class);
-		// new BukkitRunnable() {
+		// new FoliaRunnable() {
 		// @Override
 		// public void run() {
 		Gun g = me.zombie_striker.qg.api.QualityArmory.getGunByName(gun);

--- a/src/main/java/me/zombie_striker/qg/npcs/goals/Gunnergoal.java
+++ b/src/main/java/me/zombie_striker/qg/npcs/goals/Gunnergoal.java
@@ -147,7 +147,7 @@ public class Gunnergoal implements Goal {
 					Bukkit.broadcastMessage("Shooting no target");
 				}
 				// Bukkit.broadcastMessage("run1");
-				// new BukkitRunnable() {
+				// new FoliaRunnable() {
 				// public void run() {
 				// GunUtil.shoot(g, (Player) npc.getEntity(), g.getSway(), g.getDamage(), 1,
 				// g.getMaxDistance());

--- a/src/main/java/me/zombie_striker/qg/util/FoliaRunnable.java
+++ b/src/main/java/me/zombie_striker/qg/util/FoliaRunnable.java
@@ -1,0 +1,383 @@
+package me.zombie_striker.qg.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Drop-in replacement for BukkitRunnable with Folia support.
+ *
+ * On Folia: sync tasks use GlobalRegionScheduler, async uses AsyncScheduler.
+ * On Bukkit/Spigot/Paper: delegates to Bukkit.getScheduler().
+ *
+ * Entity-aware variants (runTaskLater(plugin, entity, delay)) use the
+ * EntityScheduler on Folia for thread-safe entity access.
+ *
+ * Usage: replace "new BukkitRunnable()" with "new FoliaRunnable()".
+ * For direct Bukkit.getScheduler() calls, use FoliaRunnable.runTask() static helpers.
+ */
+public abstract class FoliaRunnable implements Runnable {
+
+    private static final boolean IS_FOLIA;
+
+    static {
+        boolean folia;
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            folia = true;
+        } catch (ClassNotFoundException e) {
+            folia = false;
+        }
+        IS_FOLIA = folia;
+    }
+
+    private volatile Object task;
+    private volatile boolean cancelled = false;
+
+    public static boolean isFolia() {
+        return IS_FOLIA;
+    }
+
+    public boolean isCancelled() {
+        if (!IS_FOLIA && task instanceof BukkitTask) {
+            return ((BukkitTask) task).isCancelled();
+        }
+        return cancelled;
+    }
+
+    public void cancel() {
+        cancelled = true;
+        if (task == null) return;
+        if (!IS_FOLIA) {
+            if (task instanceof BukkitTask) ((BukkitTask) task).cancel();
+        } else {
+            try {
+                task.getClass().getMethod("cancel").invoke(task);
+            } catch (Exception ignored) {}
+        }
+    }
+
+    private void setTask(Object t) {
+        this.task = t;
+    }
+
+    // ===================== Sync (global region on Folia) =====================
+
+    public BukkitTask runTask(Plugin plugin) {
+        if (!IS_FOLIA) {
+            BukkitTask t = Bukkit.getScheduler().runTask(plugin, this);
+            setTask(t);
+            return t;
+        }
+        return scheduleGlobal(plugin, 1, -1);
+    }
+
+    public BukkitTask runTaskLater(Plugin plugin, long delay) {
+        if (!IS_FOLIA) {
+            BukkitTask t = Bukkit.getScheduler().runTaskLater(plugin, this, delay);
+            setTask(t);
+            return t;
+        }
+        return scheduleGlobal(plugin, Math.max(1, delay), -1);
+    }
+
+    public BukkitTask runTaskTimer(Plugin plugin, long delay, long period) {
+        if (!IS_FOLIA) {
+            BukkitTask t = Bukkit.getScheduler().runTaskTimer(plugin, this, delay, period);
+            setTask(t);
+            return t;
+        }
+        return scheduleGlobal(plugin, Math.max(1, delay), period);
+    }
+
+    // ===================== Async =====================
+
+    public BukkitTask runTaskAsynchronously(Plugin plugin) {
+        if (!IS_FOLIA) {
+            BukkitTask t = Bukkit.getScheduler().runTaskAsynchronously(plugin, this);
+            setTask(t);
+            return t;
+        }
+        return scheduleAsync(plugin, 0, -1);
+    }
+
+    public BukkitTask runTaskLaterAsynchronously(Plugin plugin, long delay) {
+        if (!IS_FOLIA) {
+            BukkitTask t = Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, this, delay);
+            setTask(t);
+            return t;
+        }
+        return scheduleAsync(plugin, delay, -1);
+    }
+
+    public BukkitTask runTaskTimerAsynchronously(Plugin plugin, long delay, long period) {
+        if (!IS_FOLIA) {
+            BukkitTask t = Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, this, delay, period);
+            setTask(t);
+            return t;
+        }
+        return scheduleAsync(plugin, delay, period);
+    }
+
+    // ===================== Entity-aware (EntityScheduler on Folia) =====================
+
+    public BukkitTask runTask(Plugin plugin, Entity entity) {
+        if (!IS_FOLIA) return runTask(plugin);
+        return scheduleEntity(plugin, entity, 1, -1);
+    }
+
+    public BukkitTask runTaskLater(Plugin plugin, Entity entity, long delay) {
+        if (!IS_FOLIA) return runTaskLater(plugin, delay);
+        return scheduleEntity(plugin, entity, Math.max(1, delay), -1);
+    }
+
+    public BukkitTask runTaskTimer(Plugin plugin, Entity entity, long delay, long period) {
+        if (!IS_FOLIA) return runTaskTimer(plugin, delay, period);
+        return scheduleEntity(plugin, entity, Math.max(1, delay), period);
+    }
+
+    // ===================== Location-aware (RegionScheduler on Folia) =====================
+
+    public BukkitTask runTask(Plugin plugin, Location location) {
+        if (!IS_FOLIA) return runTask(plugin);
+        return scheduleRegion(plugin, location, 1, -1);
+    }
+
+    public BukkitTask runTaskLater(Plugin plugin, Location location, long delay) {
+        if (!IS_FOLIA) return runTaskLater(plugin, delay);
+        return scheduleRegion(plugin, location, Math.max(1, delay), -1);
+    }
+
+    public BukkitTask runTaskTimer(Plugin plugin, Location location, long delay, long period) {
+        if (!IS_FOLIA) return runTaskTimer(plugin, delay, period);
+        return scheduleRegion(plugin, location, Math.max(1, delay), period);
+    }
+
+    // ===================== Static helper methods =====================
+
+    /** Run a task on the next tick (or global region tick on Folia). */
+    public static void runTask(Plugin plugin, Runnable task) {
+        if (!IS_FOLIA) {
+            Bukkit.getScheduler().runTask(plugin, task);
+            return;
+        }
+        invokeGlobal(plugin, task, 1, -1);
+    }
+
+    /** Run a task after a delay. */
+    public static void runTaskLater(Plugin plugin, Runnable task, long delay) {
+        if (!IS_FOLIA) {
+            Bukkit.getScheduler().runTaskLater(plugin, task, delay);
+            return;
+        }
+        invokeGlobal(plugin, task, Math.max(1, delay), -1);
+    }
+
+    /** Run a task asynchronously. */
+    public static void runTaskAsync(Plugin plugin, Runnable task) {
+        if (!IS_FOLIA) {
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, task);
+            return;
+        }
+        invokeAsync(plugin, task, 0, -1);
+    }
+
+    /** Run a task asynchronously after a tick delay. */
+    public static void runTaskAsyncLater(Plugin plugin, Runnable task, long delayTicks) {
+        if (!IS_FOLIA) {
+            Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, task, delayTicks);
+            return;
+        }
+        invokeAsync(plugin, task, delayTicks, -1);
+    }
+
+    /** Run on an entity's regional thread (falls back to global on Bukkit). */
+    public static void runEntityTask(Plugin plugin, Entity entity, Runnable task) {
+        if (!IS_FOLIA) {
+            Bukkit.getScheduler().runTask(plugin, task);
+            return;
+        }
+        invokeEntity(plugin, entity, task, 1, -1);
+    }
+
+    /** Run delayed on an entity's regional thread. */
+    public static void runEntityTaskLater(Plugin plugin, Entity entity, Runnable task, long delay) {
+        if (!IS_FOLIA) {
+            Bukkit.getScheduler().runTaskLater(plugin, task, delay);
+            return;
+        }
+        invokeEntity(plugin, entity, task, Math.max(1, delay), -1);
+    }
+
+    // ===================== Private scheduling implementations =====================
+
+    private BukkitTask scheduleGlobal(Plugin plugin, long delay, long period) {
+        Consumer<Object> consumer = t -> { setTask(t); if (!cancelled) run(); };
+        Object st = invokeGlobal(plugin, consumer, delay, period);
+        if (st != null) setTask(st);
+        return new FoliaTaskWrapper(st);
+    }
+
+    private BukkitTask scheduleAsync(Plugin plugin, long delayTicks, long periodTicks) {
+        Consumer<Object> consumer = t -> { setTask(t); if (!cancelled) run(); };
+        Object st = invokeAsync(plugin, consumer, delayTicks, periodTicks);
+        if (st != null) setTask(st);
+        return new FoliaTaskWrapper(st);
+    }
+
+    private BukkitTask scheduleEntity(Plugin plugin, Entity entity, long delay, long period) {
+        Consumer<Object> consumer = t -> { setTask(t); if (!cancelled) run(); };
+        Object st = invokeEntity(plugin, entity, consumer, delay, period);
+        if (st != null) setTask(st);
+        return new FoliaTaskWrapper(st);
+    }
+
+    private BukkitTask scheduleRegion(Plugin plugin, Location location, long delay, long period) {
+        Consumer<Object> consumer = t -> { setTask(t); if (!cancelled) run(); };
+        Object st = invokeRegion(plugin, location, consumer, delay, period);
+        if (st != null) setTask(st);
+        return new FoliaTaskWrapper(st);
+    }
+
+    private static Object invokeGlobal(Plugin plugin, Object consumer, long delay, long period) {
+        try {
+            Object scheduler = plugin.getServer().getClass()
+                    .getMethod("getGlobalRegionScheduler").invoke(plugin.getServer());
+            if (period >= 0) {
+                return scheduler.getClass()
+                        .getMethod("runAtFixedRate", Plugin.class, Consumer.class, long.class, long.class)
+                        .invoke(scheduler, plugin, consumer, delay, period);
+            } else if (delay > 1) {
+                return scheduler.getClass()
+                        .getMethod("runDelayed", Plugin.class, Consumer.class, long.class)
+                        .invoke(scheduler, plugin, consumer, delay);
+            } else {
+                return scheduler.getClass()
+                        .getMethod("run", Plugin.class, Consumer.class)
+                        .invoke(scheduler, plugin, consumer);
+            }
+        } catch (Exception e) {
+            plugin.getLogger().severe("[QualityArmory] Failed to schedule global Folia task: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private static void invokeGlobal(Plugin plugin, Runnable task, long delay, long period) {
+        invokeGlobal(plugin, (Consumer<Object>) t -> task.run(), delay, period);
+    }
+
+    private static Object invokeAsync(Plugin plugin, Object consumer, long delayTicks, long periodTicks) {
+        try {
+            Object scheduler = plugin.getServer().getClass()
+                    .getMethod("getAsyncScheduler").invoke(plugin.getServer());
+            if (periodTicks >= 0) {
+                return scheduler.getClass()
+                        .getMethod("runAtFixedRate", Plugin.class, Consumer.class, long.class, long.class, TimeUnit.class)
+                        .invoke(scheduler, plugin, consumer,
+                                Math.max(1, delayTicks) * 50L, periodTicks * 50L, TimeUnit.MILLISECONDS);
+            } else if (delayTicks > 0) {
+                return scheduler.getClass()
+                        .getMethod("runDelayed", Plugin.class, Consumer.class, long.class, TimeUnit.class)
+                        .invoke(scheduler, plugin, consumer, delayTicks * 50L, TimeUnit.MILLISECONDS);
+            } else {
+                return scheduler.getClass()
+                        .getMethod("runNow", Plugin.class, Consumer.class)
+                        .invoke(scheduler, plugin, consumer);
+            }
+        } catch (Exception e) {
+            plugin.getLogger().severe("[QualityArmory] Failed to schedule async Folia task: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private static void invokeAsync(Plugin plugin, Runnable task, long delayTicks, long periodTicks) {
+        invokeAsync(plugin, (Consumer<Object>) t -> task.run(), delayTicks, periodTicks);
+    }
+
+    private static Object invokeEntity(Plugin plugin, Entity entity, Object consumer, long delay, long period) {
+        try {
+            Object scheduler = entity.getClass().getMethod("getScheduler").invoke(entity);
+            if (period >= 0) {
+                return scheduler.getClass()
+                        .getMethod("runAtFixedRate", Plugin.class, Consumer.class, Runnable.class, long.class, long.class)
+                        .invoke(scheduler, plugin, consumer, (Runnable) null, delay, period);
+            } else if (delay > 1) {
+                return scheduler.getClass()
+                        .getMethod("runDelayed", Plugin.class, Consumer.class, Runnable.class, long.class)
+                        .invoke(scheduler, plugin, consumer, (Runnable) null, delay);
+            } else {
+                return scheduler.getClass()
+                        .getMethod("run", Plugin.class, Consumer.class, Runnable.class)
+                        .invoke(scheduler, plugin, consumer, (Runnable) null);
+            }
+        } catch (Exception e) {
+            plugin.getLogger().severe("[QualityArmory] Failed to schedule entity Folia task: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private static void invokeEntity(Plugin plugin, Entity entity, Runnable task, long delay, long period) {
+        invokeEntity(plugin, entity, (Consumer<Object>) t -> task.run(), delay, period);
+    }
+
+    private static Object invokeRegion(Plugin plugin, Location location, Object consumer, long delay, long period) {
+        try {
+            Object scheduler = plugin.getServer().getClass()
+                    .getMethod("getRegionScheduler").invoke(plugin.getServer());
+            if (period >= 0) {
+                return scheduler.getClass()
+                        .getMethod("runAtFixedRate", Plugin.class, Location.class, Consumer.class, long.class, long.class)
+                        .invoke(scheduler, plugin, location, consumer, delay, period);
+            } else if (delay > 1) {
+                return scheduler.getClass()
+                        .getMethod("runDelayed", Plugin.class, Location.class, Consumer.class, long.class)
+                        .invoke(scheduler, plugin, location, consumer, delay);
+            } else {
+                return scheduler.getClass()
+                        .getMethod("run", Plugin.class, Location.class, Consumer.class)
+                        .invoke(scheduler, plugin, location, consumer);
+            }
+        } catch (Exception e) {
+            plugin.getLogger().severe("[QualityArmory] Failed to schedule region Folia task: " + e.getMessage());
+            return null;
+        }
+    }
+
+    // ===================== BukkitTask wrapper for Folia ScheduledTask =====================
+
+    private final class FoliaTaskWrapper implements BukkitTask {
+        private final Object scheduledTask;
+
+        FoliaTaskWrapper(Object scheduledTask) {
+            this.scheduledTask = scheduledTask;
+        }
+
+        @Override public int getTaskId() { return -1; }
+        @Override public Plugin getOwner() { return null; }
+        @Override public boolean isSync() { return true; }
+
+        @Override
+        public boolean isCancelled() {
+            if (scheduledTask == null) return true;
+            try {
+                return (boolean) scheduledTask.getClass().getMethod("isCancelled").invoke(scheduledTask);
+            } catch (Exception e) {
+                return cancelled;
+            }
+        }
+
+        @Override
+        public void cancel() {
+            cancelled = true;
+            if (scheduledTask == null) return;
+            try {
+                scheduledTask.getClass().getMethod("cancel").invoke(scheduledTask);
+            } catch (Exception ignored) {}
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 main: me.zombie_striker.qg.QAMain
 version: ${project.version}
-api-version: 1.13
+api-version: 1.20
+folia-supported: true
 name: QualityArmory
 commands:
   QualityArmory:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Folia compatibility across weapons, reloads, projectiles, grenades, effects, metrics, and updater tasks.
  * Updated the plugin to declare Folia support and target Minecraft 1.20.

* **Bug Fixes**
  * Improved reliability of player- and location-based delayed and repeating actions.
  * Ensured scheduled effects run in the appropriate context.
  * Prevented cleared wounds from restarting bleeding unexpectedly.
  * Improved consistency for concurrent player actions and resource-pack handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->